### PR TITLE
Add the maven flatten plugin to deploy dominion-ecs modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ hs_err_pid*
 .idea
 *.iml
 **/target/
+**/.flattened-pom.xml

--- a/dominion-ecs-engine/src/test/java/module-info.java
+++ b/dominion-ecs-engine/src/test/java/module-info.java
@@ -1,12 +1,5 @@
-module dev.dominion.ecs.test.engine {
+open module dev.dominion.ecs.test.engine {
     requires dev.dominion.ecs.engine;
     requires org.junit.jupiter.api;
     requires org.junit.jupiter.engine;
-
-    opens dev.dominion.ecs.test.engine
-            to org.junit.platform.commons;
-    opens dev.dominion.ecs.test.engine.collections
-            to org.junit.platform.commons;
-    opens dev.dominion.ecs.test.engine.system
-            to org.junit.platform.commons;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,30 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.1</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.2</version>
+                <configuration>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
             <plugins>
                 <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->


### PR DESCRIPTION
Add the maven flatten plugin to deploy dominion-ecs modules by resolving the revision property before publish