### PR TITLE
free old memory when moving stack on increase

### DIFF
--- a/dominion-ecs-engine/src/main/java/dev/dominion/ecs/engine/collections/IntStack.java
+++ b/dominion-ecs-engine/src/main/java/dev/dominion/ecs/engine/collections/IntStack.java
@@ -46,6 +46,7 @@ public final class IntStack implements AutoCloseable {
                     int newCapacity = currentCapacity + (currentCapacity >>> 1);
                     long newAddress = unsafe.allocateMemory(newCapacity);
                     unsafe.copyMemory(address, newAddress, currentCapacity);
+                    unsafe.freeMemory(address);
                     capacity = newCapacity;
                     address = newAddress;
                 }


### PR DESCRIPTION
When moving the stack to a new location, the old memory is never freed.