### PR TITLE
dev.dominion.ecs.api.Results add size() method which returns the number of entities in this result.

### DIFF
--- a/dominion-ecs-api/src/main/java/dev/dominion/ecs/api/Results.java
+++ b/dominion-ecs-api/src/main/java/dev/dominion/ecs/api/Results.java
@@ -41,6 +41,13 @@ public interface Results<T> extends Iterable<T> {
     Stream<T> parallelStream();
 
     /**
+     * Returns the number of entities in this result.
+     *
+     * @return the number of entities in this result.
+     */
+    int size();
+
+    /**
      * Provides a filtered Results without one or more component types to exclude.
      *
      * @param componentTypes one or more component types to exclude

--- a/dominion-ecs-engine-benchmarks/src/main/java/dev/dominion/ecs/engine/benchmarks/EntityRepositoryBenchmark.java
+++ b/dominion-ecs-engine-benchmarks/src/main/java/dev/dominion/ecs/engine/benchmarks/EntityRepositoryBenchmark.java
@@ -8,7 +8,11 @@ package dev.dominion.ecs.engine.benchmarks;
 import dev.dominion.ecs.api.Composition;
 import dev.dominion.ecs.api.Entity;
 import dev.dominion.ecs.engine.EntityRepository;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 
 public class EntityRepositoryBenchmark extends DominionBenchmark {
@@ -352,6 +356,12 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
             streamWithStateImpl(bh);
         }
 
+        @Benchmark
+        public void size(Blackhole bh) { sizeImpl(bh); }
+
+        @Benchmark
+        public void sizeWithState(Blackhole bh) { sizeWidthStateImpl(bh); }
+
         abstract void iterateImpl(Blackhole bh);
 
         abstract void iterateWithStateImpl(Blackhole bh);
@@ -359,6 +369,10 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
         abstract void streamImpl(Blackhole bh);
 
         abstract void streamWithStateImpl(Blackhole bh);
+
+        abstract void sizeImpl(Blackhole bh);
+
+        abstract void sizeWidthStateImpl(Blackhole bh);
 
         @TearDown()
         public void tearDown() {
@@ -412,6 +426,14 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
             var stream =
                     entityRepository.findEntitiesWith(C1.class).withState(State1.ONE).stream();
             stream.forEach(bh::consume);
+        }
+
+        @Override void sizeImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class).size());
+        }
+
+        @Override void sizeWidthStateImpl(Blackhole bh) {
+            bh.consume(entityRepository.findEntitiesWith(C1.class).withState(State1.ONE).size());
         }
     }
 //
@@ -483,6 +505,14 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
             var stream =
                     entityRepository.findCompositionsWith(C1.class, C2.class).withState(State1.ONE).stream();
             stream.forEach(bh::consume);
+        }
+
+        @Override void sizeImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class).size());
+        }
+
+        @Override void sizeWidthStateImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class).withState(State1.ONE).size());
         }
     }
 //
@@ -556,6 +586,14 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
             var stream =
                     entityRepository.findCompositionsWith(C1.class, C2.class, C3.class).withState(State1.ONE).stream();
             stream.forEach(bh::consume);
+        }
+
+        @Override void sizeImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class).size());
+        }
+
+        @Override void sizeWidthStateImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class).withState(State1.ONE).size());
         }
     }
 //
@@ -632,6 +670,15 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
                     entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class)
                             .withState(State1.ONE).stream();
             stream.forEach(bh::consume);
+        }
+
+        @Override void sizeImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class).size());
+        }
+
+        @Override void sizeWidthStateImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class)
+                    .withState(State1.ONE).size());
         }
     }
 //
@@ -712,6 +759,15 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
                             .withState(State1.ONE).stream();
             stream.forEach(bh::consume);
         }
+
+        @Override void sizeImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class, C5.class).size());
+        }
+
+        @Override void sizeWidthStateImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class, C5.class)
+                    .withState(State1.ONE).size());
+        }
     }
 //
 //    public static class FindComponents5FromMoreCompositions extends FindComponents5 {
@@ -789,6 +845,15 @@ public class EntityRepositoryBenchmark extends DominionBenchmark {
                     entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class, C5.class, C6.class)
                             .withState(State1.ONE).stream();
             stream.forEach(bh::consume);
+        }
+
+        @Override void sizeImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class, C5.class, C6.class).size());
+        }
+
+        @Override void sizeWidthStateImpl(Blackhole bh) {
+            bh.consume(entityRepository.findCompositionsWith(C1.class, C2.class, C3.class, C4.class, C5.class, C6.class)
+                    .withState(State1.ONE).size());
         }
     }
 //

--- a/dominion-ecs-engine/src/main/java/dev/dominion/ecs/engine/ResultSet.java
+++ b/dominion-ecs-engine/src/main/java/dev/dominion/ecs/engine/ResultSet.java
@@ -72,19 +72,11 @@ public abstract class ResultSet<T> implements Results<T> {
         if (nodeMap == null || nodeMap.isEmpty()) return 0;
 
         var size = 0;
-        if (nodeMap.size() > 1) {
-            for (CompositionRepository.Node node : nodeMap.values()) {
-                final var composition = node.getComposition();
-                final var sizeIterator = getPoolSizeIterator(composition);
-                while (sizeIterator.hasNext()) {
-                    size += sizeIterator.next();
-                }
-            }
-        } else {
-            var composition = nodeMap.values().iterator().next().getComposition();
-            var iterator = getPoolSizeIterator(composition);
-            while (iterator.hasNext()) {
-                size += iterator.next();
+        for (CompositionRepository.Node node : nodeMap.values()) {
+            final var composition = node.getComposition();
+            final var sizeIterator = getPoolSizeIterator(composition);
+            while (sizeIterator.hasNext()) {
+                size += sizeIterator.next();
             }
         }
         return size;

--- a/dominion-ecs-engine/src/test/java/dev/dominion/ecs/test/engine/EntityRepositoryTest.java
+++ b/dominion-ecs-engine/src/test/java/dev/dominion/ecs/test/engine/EntityRepositoryTest.java
@@ -241,6 +241,8 @@ class EntityRepositoryTest {
         Assertions.assertTrue(iterator.hasNext());
         Assertions.assertEquals(entities[0], iterator.next());
         Assertions.assertFalse(iterator.hasNext());
+
+        Assertions.assertEquals(6, entityRepository.findAllEntities().size());
     }
 
 
@@ -281,6 +283,12 @@ class EntityRepositoryTest {
         Assertions.assertEquals(c5, entityRepository.findEntitiesWith(C1.class, C2.class, C3.class, C4.class, C5.class).iterator().next().comp5());
         Assertions.assertEquals(c5, entityRepository.findEntitiesWith(C1.class, C2.class, C3.class, C4.class, C5.class, C6.class).iterator().next().comp5());
         Assertions.assertEquals(c6, entityRepository.findEntitiesWith(C1.class, C2.class, C3.class, C4.class, C5.class, C6.class).iterator().next().comp6());
+
+        Assertions.assertEquals(6, entityRepository.findEntitiesWith(C1.class).size());
+        Assertions.assertEquals(5, entityRepository.findEntitiesWith(C1.class, C2.class).size());
+        Assertions.assertEquals(4, entityRepository.findEntitiesWith(C1.class, C3.class).size());
+        Assertions.assertEquals(1, entityRepository.findEntitiesWith(C1.class, C2.class, C3.class, C4.class, C5.class, C6.class).size());
+        Assertions.assertEquals(0, entityRepository.findEntitiesWith(C7.class).size());
     }
 
     @Test
@@ -337,6 +345,8 @@ class EntityRepositoryTest {
         Assertions.assertEquals(13, next4.comp().id);
         Assertions.assertFalse(iterator4.hasNext());
 
+        Assertions.assertEquals(2, results1.withState(State.TWO).size());
+        Assertions.assertEquals(3, results1.withState(State.ONE).size());
     }
 
     @Test
@@ -357,6 +367,7 @@ class EntityRepositoryTest {
         next = iterator.next();
         Assertions.assertEquals(1, next.comp().id);
         Assertions.assertEquals(entity2, next.entity());
+        Assertions.assertEquals(2, results.size());
 
         var results2 = entityRepository.findEntitiesWith(C2.class);
         var iterator2 = results2.iterator();
@@ -365,11 +376,13 @@ class EntityRepositoryTest {
         var next2 = iterator2.next();
         Assertions.assertEquals(2, next2.comp().id);
         Assertions.assertEquals(entity2, next2.entity());
+        Assertions.assertEquals(1, results2.size());
 
         var results3 = entityRepository.findEntitiesWith(C3.class);
         var iterator3 = results3.iterator();
         Assertions.assertNotNull(iterator3);
         Assertions.assertFalse(iterator3.hasNext());
+        Assertions.assertEquals(0, results3.size());
     }
 
     @Test
@@ -408,8 +421,10 @@ class EntityRepositoryTest {
         EntityRepository entityRepository = (EntityRepository) new EntityRepository.Factory().create("test");
         entityRepository.createEntity(new C1(0));
         AtomicInteger count = new AtomicInteger(0);
-        entityRepository.findEntitiesWith(C1.class, C2.class).stream().forEach((rs) -> count.incrementAndGet());
+        final var results = entityRepository.findEntitiesWith(C1.class, C2.class);
+        results.stream().forEach((rs) -> count.incrementAndGet());
         Assertions.assertEquals(0, count.get());
+        Assertions.assertEquals(0, results.size());
 
         AtomicInteger count1 = new AtomicInteger(0);
         entityRepository.findEntitiesWith(C1.class, C2.class).parallelStream().forEach((rs) -> count1.incrementAndGet());
@@ -418,8 +433,10 @@ class EntityRepositoryTest {
         entityRepository = (EntityRepository) new EntityRepository.Factory().create("test");
         entityRepository.createEntity(new C1(0), new C2(0));
         AtomicInteger count2 = new AtomicInteger(0);
-        entityRepository.findEntitiesWith(C1.class, C2.class, C3.class).stream().forEach((rs) -> count2.incrementAndGet());
+        final var results2 = entityRepository.findEntitiesWith(C1.class, C2.class, C3.class);
+        results2.stream().forEach((rs) -> count2.incrementAndGet());
         Assertions.assertEquals(0, count2.get());
+        Assertions.assertEquals(0, results2.size());
 
         AtomicInteger count3 = new AtomicInteger(0);
         entityRepository.findEntitiesWith(C1.class, C2.class, C3.class).parallelStream().forEach((rs) -> count3.incrementAndGet());
@@ -432,8 +449,10 @@ class EntityRepositoryTest {
         entityRepository.createEntity(new C1(0), new C2(0));
         entityRepository.createEntity(new C3(0), new C4(0));
         AtomicInteger count = new AtomicInteger(0);
-        entityRepository.findEntitiesWith(C1.class, C3.class).stream().forEach((rs) -> count.incrementAndGet());
+        final var results = entityRepository.findEntitiesWith(C1.class, C3.class);
+        results.stream().forEach((rs) -> count.incrementAndGet());
         Assertions.assertEquals(0, count.get());
+        Assertions.assertEquals(0, results.size());
 
         AtomicInteger count1 = new AtomicInteger(0);
         entityRepository.findEntitiesWith(C1.class, C3.class).parallelStream().forEach((rs) -> count1.incrementAndGet());
@@ -445,16 +464,20 @@ class EntityRepositoryTest {
         EntityRepository entityRepository = (EntityRepository) new EntityRepository.Factory().create("test");
         entityRepository.createEntity(new C1(0), new C2(0));
         AtomicInteger count = new AtomicInteger(0);
-        entityRepository.findEntitiesWith(C1.class).withAlso(C3.class).stream().forEach((rs) -> count.incrementAndGet());
+        final var results = entityRepository.findEntitiesWith(C1.class).withAlso(C3.class);
+        results.stream().forEach((rs) -> count.incrementAndGet());
         Assertions.assertEquals(0, count.get());
+        Assertions.assertEquals(0, results.size());
 
         AtomicInteger count1 = new AtomicInteger(0);
         entityRepository.findEntitiesWith(C1.class).withAlso(C3.class).parallelStream().forEach((rs) -> count1.incrementAndGet());
         Assertions.assertEquals(0, count1.get());
 
         AtomicInteger count2 = new AtomicInteger(0);
-        entityRepository.findEntitiesWith(C3.class).withAlso(C1.class).stream().forEach((rs) -> count2.incrementAndGet());
+        final var results2 = entityRepository.findEntitiesWith(C3.class).withAlso(C1.class);
+        results2.stream().forEach((rs) -> count2.incrementAndGet());
         Assertions.assertEquals(0, count2.get());
+        Assertions.assertEquals(0, results2.size());
 
         AtomicInteger count3 = new AtomicInteger(0);
         entityRepository.findEntitiesWith(C3.class).withAlso(C1.class).parallelStream().forEach((rs) -> count3.incrementAndGet());
@@ -466,16 +489,20 @@ class EntityRepositoryTest {
         EntityRepository entityRepository = (EntityRepository) new EntityRepository.Factory().create("test");
         entityRepository.createEntity(new C1(0));
         AtomicInteger count = new AtomicInteger(0);
-        entityRepository.findEntitiesWith(C1.class).without(C3.class).stream().forEach((rs) -> count.incrementAndGet());
+        final var results = entityRepository.findEntitiesWith(C1.class).without(C3.class);
+        results.stream().forEach((rs) -> count.incrementAndGet());
         Assertions.assertEquals(1, count.get());
+        Assertions.assertEquals(1, results.size());
 
         AtomicInteger count1 = new AtomicInteger(0);
         entityRepository.findEntitiesWith(C1.class).without(C3.class).parallelStream().forEach((rs) -> count1.incrementAndGet());
         Assertions.assertEquals(1, count1.get());
 
         AtomicInteger count2 = new AtomicInteger(0);
-        entityRepository.findEntitiesWith(C3.class).without(C1.class).stream().forEach((rs) -> count2.incrementAndGet());
+        final var results2 = entityRepository.findEntitiesWith(C3.class).without(C1.class);
+        results2.stream().forEach((rs) -> count2.incrementAndGet());
         Assertions.assertEquals(0, count2.get());
+        Assertions.assertEquals(0, results2.size());
 
         AtomicInteger count3 = new AtomicInteger(0);
         entityRepository.findEntitiesWith(C3.class).without(C1.class).parallelStream().forEach((rs) -> count3.incrementAndGet());
@@ -511,16 +538,20 @@ class EntityRepositoryTest {
         entityRepository.createEntity(new C1(1));
         entityRepository.createEntity(new C1(2));
         entityRepository.createEntity(new C1(3));
-        var iterator = entityRepository.findEntitiesWith(C1.class).iterator();
+        final var results = entityRepository.findEntitiesWith(C1.class);
+        var iterator = results.iterator();
         Assertions.assertTrue(iterator.hasNext());
+        Assertions.assertEquals(4, results.size());
         while (iterator.hasNext()) {
             var next = iterator.next();
             next.entity().setEnabled(false);
             System.out.println("next.comp() = " + next.comp());
         }
-        iterator = entityRepository.findEntitiesWith(C1.class).iterator();
+        final var results2 = entityRepository.findEntitiesWith(C1.class);
+        iterator = results2.iterator();
         Assertions.assertFalse(iterator.hasNext());
         Assertions.assertFalse(iterator.hasNext());
+        Assertions.assertEquals(0, results2.size());
     }
 
     @Test
@@ -552,5 +583,8 @@ class EntityRepositoryTest {
     }
 
     record C6(int id) {
+    }
+
+    record C7(int id) {
     }
 }


### PR DESCRIPTION
`dev.dominion.ecs.api.Results` add `size()` method which returns the number of entities in this result.
It can be used in debugging output, data statistics and other scenarios.
Please check my unit tests and benchmark, I'm not good at these, Thank you.